### PR TITLE
Rework parser API - Drop parsing specific to dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,60 +1,30 @@
-# ducktools: pep723parser #
+# ducktools: script_metadata_parser #
 
 Parser for embedded metadata in python source files 
 as defined in [PEP723](https://peps.python.org/pep-0723/).
 
-## Example ##
+Inline script metadata can be extracted from a file path, from a string
+or from an iterable of lines (such as an open file).
 
-```python
-from ducktools.pep723parser import EmbeddedMetadata
-from pprint import pprint
-
-metadata = EmbeddedMetadata.from_path("examples/pep-723-sample.py")
-
-pprint(metadata.run_requirements)
-```
-
-Output:
-```
-{'dependencies': [<Requirement('requests<3')>, <Requirement('rich')>],
- 'requires-python': <SpecifierSet('>=3.11')>}
-```
-
-## Available Methods ##
-
-Embedded metadata can be extracted via 2 class methods.
+This module does not attempt to parse the contents of the metadata blocks
+in any way.
 
 ```python
 from pathlib import Path
 
-from ducktools.pep723parser import EmbeddedMetadata
+from ducktools.script_metadata_parser import ScriptMetadata
 
 src_path = Path("examples/pep-723-sample.py")
 
 # Create a parser from a path to a source file
-metadata = EmbeddedMetadata.from_path(src_path, encoding="utf-8")
+metadata = ScriptMetadata.from_path(src_path, encoding="utf-8")
 
 # Create a parser from source code as a string
-metadata = EmbeddedMetadata.from_string(src_path.read_text())
+metadata = ScriptMetadata.from_string(src_path.read_text())
 
 # Get all metadata blocks and unprocessed text as a dict
 metadata.blocks
 
-# Return the unprocessed pyproject block text or None 
-# if there is no block
-metadata.pyproject_text
-
-# Return the pyproject block processed by tomllib/tomli
-# or return an empty dict if there is no block
-metadata.pyproject_toml
-
-# Return the [run] block from the pyproject block
-# requires-python and dependencies values will exist
-# as empty data even if not defined in the block
-metadata.run_requirements_text
-
-# Return the [run] block from the pyproject block
-# with requires-python and dependencies values processed
-# by packaging into SpecifierSet and Requirement objects
-metadata.run_requirements
+# View any warnings about potentially malformed blocks
+metadata.warnings
 ```

--- a/examples/pep-723-sample.py
+++ b/examples/pep-723-sample.py
@@ -1,5 +1,4 @@
-# /// pyproject
-# [run]
+# /// script
 # requires-python = ">=3.11"
 # dependencies = [
 #   "requests<3",

--- a/perf/ducktools_parse.py
+++ b/perf/ducktools_parse.py
@@ -1,0 +1,9 @@
+import os.path
+
+from ducktools.script_metadata_parser import parse_file
+
+pth = os.path.realpath(f"{os.path.dirname(__file__)}/../examples/pep-723-sample.py")
+
+data = parse_file(pth)
+
+print(data.blocks)

--- a/perf/import_parse.py
+++ b/perf/import_parse.py
@@ -1,9 +1,0 @@
-import os.path
-
-from ducktools.script_metadata_parser import ScriptMetadata
-
-pth = os.path.realpath(f"{os.path.dirname(__file__)}/../examples/pep-723-sample.py")
-
-data = ScriptMetadata.from_path(pth)
-
-output = data.pyproject_text

--- a/perf/import_parse.py
+++ b/perf/import_parse.py
@@ -1,9 +1,9 @@
 import os.path
 
-from ducktools.pep723parser import EmbeddedMetadata
+from ducktools.script_metadata_parser import ScriptMetadata
 
 pth = os.path.realpath(f"{os.path.dirname(__file__)}/../examples/pep-723-sample.py")
 
-data = EmbeddedMetadata.from_path(pth)
+data = ScriptMetadata.from_path(pth)
 
 output = data.pyproject_text

--- a/perf/import_parse_requirements.py
+++ b/perf/import_parse_requirements.py
@@ -1,9 +1,9 @@
 import os.path
 
-from ducktools.pep723parser import EmbeddedMetadata
+from ducktools.script_metadata_parser import ScriptMetadata
 
 pth = os.path.realpath(f"{os.path.dirname(__file__)}/../examples/pep-723-sample.py")
 
-data = EmbeddedMetadata.from_path(pth)
+data = ScriptMetadata.from_path(pth)
 
 output = data.run_requirements

--- a/perf/import_parse_requirements.py
+++ b/perf/import_parse_requirements.py
@@ -1,9 +1,0 @@
-import os.path
-
-from ducktools.script_metadata_parser import ScriptMetadata
-
-pth = os.path.realpath(f"{os.path.dirname(__file__)}/../examples/pep-723-sample.py")
-
-data = ScriptMetadata.from_path(pth)
-
-output = data.run_requirements

--- a/perf/import_parse_toml.py
+++ b/perf/import_parse_toml.py
@@ -1,9 +1,9 @@
 import os.path
 
-from ducktools.pep723parser import EmbeddedMetadata
+from ducktools.script_metadata_parser import ScriptMetadata
 
 pth = os.path.realpath(f"{os.path.dirname(__file__)}/../examples/pep-723-sample.py")
 
-data = EmbeddedMetadata.from_path(pth)
+data = ScriptMetadata.from_path(pth)
 
 output = data.run_requirements_text

--- a/perf/import_parse_toml.py
+++ b/perf/import_parse_toml.py
@@ -1,9 +1,0 @@
-import os.path
-
-from ducktools.script_metadata_parser import ScriptMetadata
-
-pth = os.path.realpath(f"{os.path.dirname(__file__)}/../examples/pep-723-sample.py")
-
-data = ScriptMetadata.from_path(pth)
-
-output = data.run_requirements_text

--- a/perf/regex_parse.py
+++ b/perf/regex_parse.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import os.path
+import re
+
+
+try:
+    from _collections_abc import Iterator
+except ImportError:
+    from collections.abc import Iterator
+
+sample_path = os.path.realpath(f"{os.path.dirname(__file__)}/../examples/pep-723-sample.py")
+
+REGEX = r'(?m)^# /// (?P<type>[a-zA-Z0-9-]+)$\s(?P<content>(^#(| .*)$\s)+)^# ///$'
+
+
+def stream(script: str) -> Iterator[tuple[str, str]]:
+    for match in re.finditer(REGEX, script):
+        yield match.group('type'), ''.join(
+            line[2:] if line.startswith('# ') else line[1:]
+            for line in match.group('content').splitlines(keepends=True)
+        )
+
+
+def get_blocks(pth: str):
+    with open(pth, 'r') as f:
+        src = f.read()
+
+    return {name: content for name, content in stream(src)}
+
+
+print(get_blocks(sample_path))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,18 +6,14 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [project]
-name="ducktools-pep723parser"
+name="ducktools-script_metadata_parser"
 description="LazyImporter class to manage imports on attribute access."
 authors = [
   { name="David C Ellis" },
 ]
 readme="README.md"
 requires-python = ">=3.8"
-dependencies = [
-    "tomli >= 1.1.0 ; python_version < '3.11'",
-    "packaging >= 23.2",
-    "ducktools-lazyimporter >= 0.1.2",
-]
+dependencies = []
 classifiers = [
     "Development Status :: 1 - Planning",
     "Programming Language :: Python :: 3.8",
@@ -37,4 +33,10 @@ testing = ["pytest", "pytest-cov"]
 where = ["src"]
 
 [tool.setuptools.dynamic]
-version = {attr = "ducktools.pep723parser.__version__"}
+version = {attr = "ducktools.script_metadata_parser.__version__"}
+
+[tool.pytest.ini_options]
+addopts= "--cov=src/ --cov-report=term-missing"
+testpaths = [
+    "tests",
+]

--- a/src/ducktools/script_metadata_parser/__init__.py
+++ b/src/ducktools/script_metadata_parser/__init__.py
@@ -62,9 +62,7 @@ def _is_valid_type(txt: str) -> bool:
 
 
 def _iter_parse(
-        script_data: Iterable[str],
-        *,
-        start_line: int = 1
+    script_data: Iterable[str], *, start_line: int = 1
 ) -> Iterator[tuple[str | None, str | None, list[str]]]:
     """
     Iterate over source and yield embedded metadata.
@@ -210,11 +208,15 @@ class ScriptMetadata:
         return False
 
 
-def parse_iterable(iterable_data: Iterable[str], *, start_line: int = 1) -> ScriptMetadata:
+def parse_iterable(
+    iterable_data: Iterable[str], *, start_line: int = 1
+) -> ScriptMetadata:
     blocks = {}
     warnings = []
 
-    for block_name, block_text, warning_list in _iter_parse(iterable_data, start_line=start_line):
+    for block_name, block_text, warning_list in _iter_parse(
+        iterable_data, start_line=start_line
+    ):
         if block_name:
             blocks[block_name] = block_text
 
@@ -228,7 +230,9 @@ def parse_source(script_text: str, *, start_line: int = 1) -> ScriptMetadata:
     return parse_iterable(data, start_line=start_line)
 
 
-def parse_file(file_path: str | bytes | os.PathLike, *, encoding: str = "utf-8") -> ScriptMetadata:
+def parse_file(
+    file_path: str | bytes | os.PathLike, *, encoding: str = "utf-8"
+) -> ScriptMetadata:
     with open(file_path, mode="r", encoding=encoding) as f:
         metadata = parse_iterable(f)
 

--- a/tests/compliance_data/README.md
+++ b/tests/compliance_data/README.md
@@ -16,15 +16,16 @@ import pytest
 import compliance_data
 
 # Use your parser here
-from ducktools.pep723parser import EmbeddedMetadata
+from ducktools.script_metadata_parser import ScriptMetadata
+
 
 @pytest.mark.parametrize("module_name", dir(compliance_data))
 def test_compliance(module_name):
     module = getattr(compliance_data, module_name)
     module_path = module.__file__
-    
+
     try:
-        metadata = EmbeddedMetadata.from_path(module_path)
+        metadata = ScriptMetadata.from_path(module_path)
     except Exception as e:
         assert module.is_error
     else:

--- a/tests/compliance_data/__init__.py
+++ b/tests/compliance_data/__init__.py
@@ -7,6 +7,7 @@ from . import (
     repeated_block_error,
     unclosed_block_example,
     unclosed_block_eof,
+    invalid_block_name,
 )
 
 __all__ = [
@@ -18,6 +19,7 @@ __all__ = [
     "repeated_block_error",
     "unclosed_block_example",
     "unclosed_block_eof",
+    "invalid_block_name",
 ]
 
 

--- a/tests/compliance_data/basic_pep_example.py
+++ b/tests/compliance_data/basic_pep_example.py
@@ -2,8 +2,7 @@
 The original example block from the PEP.
 """
 
-# /// pyproject
-# [run]
+# /// script
 # requires-python = ">=3.11"
 # dependencies = [
 #   "requests<3",
@@ -14,9 +13,8 @@ The original example block from the PEP.
 import textwrap
 
 output = {
-    "pyproject": textwrap.dedent(
+    "script": textwrap.dedent(
         """
-        [run]
         requires-python = ">=3.11"
         dependencies = [
           "requests<3",

--- a/tests/compliance_data/invalid_block_name.py
+++ b/tests/compliance_data/invalid_block_name.py
@@ -1,0 +1,11 @@
+# Invalid block name - not a valid "type"
+
+# /// script!!
+# Anything under here should be ignored
+# ///
+
+output = {}
+is_error = False
+
+# Internal
+exact_error = None

--- a/tests/compliance_data/multiple_blocks_joined.py
+++ b/tests/compliance_data/multiple_blocks_joined.py
@@ -1,8 +1,8 @@
 # Multiple block descrepency between the regex in the pep
 # and the text description.
 
-# /// pyproject
-# run.dependencies = [
+# /// script
+# dependencies = [
 #     "ducktools-lazyimporter>=0.1.1",
 # ]
 # ///
@@ -16,9 +16,9 @@
 import textwrap
 
 output = {
-    "pyproject": textwrap.dedent(
+    "script": textwrap.dedent(
         """
-        run.dependencies = [
+        dependencies = [
             "ducktools-lazyimporter>=0.1.1",
         ]
         ///

--- a/tests/compliance_data/multiple_closing_lines.py
+++ b/tests/compliance_data/multiple_closing_lines.py
@@ -1,5 +1,4 @@
-# /// pyproject
-# [run]
+# /// script
 # dependencies = ["requests"]
 # ///
 # Additional comment
@@ -8,9 +7,8 @@
 import textwrap
 
 output = {
-    "pyproject": textwrap.dedent(
+    "script": textwrap.dedent(
         """
-        [run]
         dependencies = ["requests"]
         ///
         Additional comment

--- a/tests/compliance_data/multiple_opening_lines.py
+++ b/tests/compliance_data/multiple_opening_lines.py
@@ -1,18 +1,16 @@
-# /// pyproject
-# [run]
+# /// script
 # dependencies = ["requests"]
-# /// pyproject
+# /// script
 # requires-python = ">=3.11"
 # ///
 
 import textwrap
 
 output = {
-    "pyproject": textwrap.dedent(
+    "script": textwrap.dedent(
         """
-        [run]
         dependencies = ["requests"]
-        /// pyproject
+        /// script
         requires-python = ">=3.11"
         """
     ).lstrip()

--- a/tests/compliance_data/repeated_block_error.py
+++ b/tests/compliance_data/repeated_block_error.py
@@ -1,5 +1,4 @@
-# /// pyproject
-# [run]
+# /// script
 # requires-python = ">=3.11"
 # dependencies = [
 #   "requests<3",
@@ -7,8 +6,7 @@
 # ]
 # ///
 
-# /// pyproject
-# [run]
+# /// script
 # requires-python = ">=3.11"
 # dependencies = [
 #   "requests<3",
@@ -20,4 +18,4 @@ output = {}
 is_error = True
 
 # Internal
-exact_error = ValueError("Line 10: Duplicate 'pyproject' block found.")
+exact_error = ValueError("Line 9: Duplicate 'script' block found.")

--- a/tests/compliance_data/unclosed_block_eof.py
+++ b/tests/compliance_data/unclosed_block_eof.py
@@ -9,8 +9,7 @@ is_error = False
 exact_error = None
 
 
-# /// pyproject
-# [run]
+# /// script
 # requires-python = ">=3.11"
 # dependencies = [
 #   "requests<3",

--- a/tests/compliance_data/unclosed_block_example.py
+++ b/tests/compliance_data/unclosed_block_example.py
@@ -1,5 +1,4 @@
-# /// pyproject
-# [run]
+# /// script
 # requires-python = ">=3.11"
 # dependencies = [
 #   "requests<3",

--- a/tests/example_files/example_no_pyproject_block.py
+++ b/tests/example_files/example_no_pyproject_block.py
@@ -1,5 +1,4 @@
-# /// not-pyproject
-# [run]
+# /// not-script
 # requires-python = ">=3.11"
 # dependencies = [
 #   "requests<3",

--- a/tests/example_files/invalid_repeated_block.py
+++ b/tests/example_files/invalid_repeated_block.py
@@ -1,5 +1,4 @@
-# /// pyproject
-# [run]
+# /// script
 # requires-python = ">=3.11"
 # dependencies = [
 #   "requests<3",
@@ -7,8 +6,7 @@
 # ]
 # ///
 
-# /// pyproject
-# [run]
+# /// script
 # requires-python = ">=3.11"
 # dependencies = [
 #   "requests<3",

--- a/tests/example_files/multi_block_discrepency.py
+++ b/tests/example_files/multi_block_discrepency.py
@@ -1,8 +1,8 @@
 # Multiple block descrepency between the regex in the pep
 # and the text description.
 
-# /// pyproject
-# run.dependencies = [
+# /// script
+# dependencies = [
 #     "ducktools-lazyimporter>=0.1.1",
 # ]
 # ///

--- a/tests/example_files/pep-723-sample-noclose-eof.py
+++ b/tests/example_files/pep-723-sample-noclose-eof.py
@@ -1,5 +1,4 @@
-# /// pyproject
-# [run]
+# /// script
 # requires-python = ">=3.11"
 # dependencies = [
 #   "requests<3",

--- a/tests/example_files/pep-723-sample-noclose.py
+++ b/tests/example_files/pep-723-sample-noclose.py
@@ -1,5 +1,4 @@
-# /// pyproject
-# [run]
+# /// script
 # requires-python = ">=3.11"
 # dependencies = [
 #   "requests<3",

--- a/tests/example_files/pep-723-sample.py
+++ b/tests/example_files/pep-723-sample.py
@@ -1,12 +1,10 @@
-# /// pyproject
-# [run]
+# /// script
 # requires-python = ">=3.11"
 # dependencies = [
 #   "requests<3",
 #   "rich",
 # ]
 # ///
-
 
 import requests
 from rich.pretty import pprint

--- a/tests/example_files/toml_warning.py
+++ b/tests/example_files/toml_warning.py
@@ -1,8 +1,0 @@
-"""
-Warn if there's a `pyproject.toml` block instead of a `pyproject` block.
-"""
-
-# /// pyproject.toml
-# [run]
-# dependencies = ["tomli"]
-# ///

--- a/tests/example_files/valid_but_errors_double_block.py
+++ b/tests/example_files/valid_but_errors_double_block.py
@@ -1,5 +1,4 @@
-# /// pyproject
-# [run]
+# /// script
 # requires-python = ">=3.11"
 # dependencies = [
 #   "requests<3",

--- a/tests/test_compliance.py
+++ b/tests/test_compliance.py
@@ -2,16 +2,16 @@ from pathlib import Path
 
 import pytest
 
-from ducktools.pep723parser import EmbeddedMetadata
+from ducktools.script_metadata_parser import ScriptMetadata
 import compliance_data
 
 
 def parse_data(path, parse_type):
     path = Path(path)
     if parse_type == "string":
-        return EmbeddedMetadata.from_string(path.read_text())
+        return ScriptMetadata.from_string(path.read_text())
     elif parse_type == "path":
-        return EmbeddedMetadata.from_path(path)
+        return ScriptMetadata.from_path(path)
 
 
 @pytest.mark.parametrize("parser_type", ["string", "path"])

--- a/tests/test_compliance.py
+++ b/tests/test_compliance.py
@@ -2,16 +2,16 @@ from pathlib import Path
 
 import pytest
 
-from ducktools.script_metadata_parser import ScriptMetadata
+from ducktools.script_metadata_parser import parse_file, parse_source
 import compliance_data
 
 
 def parse_data(path, parse_type):
     path = Path(path)
     if parse_type == "string":
-        return ScriptMetadata.from_string(path.read_text())
+        return parse_source(path.read_text())
     elif parse_type == "path":
-        return ScriptMetadata.from_path(path)
+        return parse_file(path)
 
 
 @pytest.mark.parametrize("parser_type", ["string", "path"])

--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -1,101 +1,43 @@
-from ducktools.pep723parser import (
+from ducktools.script_metadata_parser import (
     _is_valid_type,
-    EmbeddedMetadata,
+    ScriptMetadata,
 )
 from pathlib import Path
-from packaging.specifiers import SpecifierSet
-from packaging.requirements import Requirement
 
-try:
-    import tomllib
-except ImportError:
-    import tomli as tomllib
 
 import pytest
 
 example_folder = Path(__file__).parent / "example_files"
 
 
-pep_723_ex_extracted_dict = {
-    "run": {
-        "requires-python": ">=3.11",
-        "dependencies": [
-            "requests<3",
-            "rich",
-        ],
-    }
-}
-
-pep_723_run_requirements_text = pep_723_ex_extracted_dict["run"]
-
-pep_723_run_requirements = {
-    "requires-python": SpecifierSet(">=3.11"),
-    "dependencies": [
-        Requirement("requests<3"),
-        Requirement("rich"),
-    ],
-}
-
-
 class TestParsePEPExample:
     @property
     def file_parser(self):
         test_file = example_folder / "pep-723-sample.py"
-        return EmbeddedMetadata.from_path(test_file)
-
-    @property
-    def str_parser(self):
-        test_file = example_folder / "pep-723-sample.py"
-        test_text = test_file.read_text()
-        return EmbeddedMetadata.from_string(test_text)
-
-    @pytest.mark.parametrize("parser_type", ["file_parser", "str_parser"])
-    def test_pep_example_file_toml(self, parser_type):
-        parser = getattr(self, parser_type)
-        output = parser.pyproject_toml
-        assert output == pep_723_ex_extracted_dict
-
-    @pytest.mark.parametrize("parser_type", ["file_parser", "str_parser"])
-    def test_pep_example_run_requirements_text(self, parser_type):
-        parser = getattr(self, parser_type)
-        output = parser.run_requirements_text
-        assert output == pep_723_run_requirements_text
-
-    @pytest.mark.parametrize("parser_type", ["file_parser", "str_parser"])
-    def test_pep_example_run_requirements(self, parser_type):
-        parser = getattr(self, parser_type)
-        output = parser.run_requirements
-        assert output == pep_723_run_requirements
+        return ScriptMetadata.from_path(test_file)
 
     def test_metadata_repr_eq(self):
         parser = self.file_parser
 
         rebuilt_parser = eval(
             repr(parser),
-            {"EmbeddedMetadata": EmbeddedMetadata}
+            {"ScriptMetadata": ScriptMetadata}
         )
 
         assert parser == rebuilt_parser
 
 
 class TestErrors:
-    def test_new_block_without_close(self):
-        test_file = example_folder / "valid_but_errors_double_block.py"
-        metadata = EmbeddedMetadata.from_path(test_file)
-
-        # Fails TOML parse
-        with pytest.raises(tomllib.TOMLDecodeError):
-            _ = metadata.pyproject_toml
 
     def test_block_not_closed(self):
         test_file = example_folder / "pep-723-sample-noclose.py"
-        metadata = EmbeddedMetadata.from_path(test_file)
+        metadata = ScriptMetadata.from_path(test_file)
         assert len(metadata.warnings) > 0
         assert "Potential unclosed block" in metadata.warnings[0]
 
     def test_block_not_closed_eof(self):
         test_file = example_folder / "pep-723-sample-noclose-eof.py"
-        metadata = EmbeddedMetadata.from_path(test_file)
+        metadata = ScriptMetadata.from_path(test_file)
 
         assert len(metadata.warnings) > 0
         assert "Potential unclosed block" in metadata.warnings[0]
@@ -104,68 +46,7 @@ class TestErrors:
         test_file = example_folder / "invalid_repeated_block.py"
 
         with pytest.raises(ValueError):
-            _ = EmbeddedMetadata.from_path(test_file)
-
-    def test_malformed_toml(self):
-        malformed = (
-            "# /// pyproject\n"
-            "# !!invalidtoml!!\n"
-            "# ///\n"
-        )
-
-        metadata = EmbeddedMetadata.from_string(malformed)
-
-        with pytest.raises(tomllib.TOMLDecodeError):
-            _ = metadata.pyproject_toml
-
-
-class TestMissing:
-    @property
-    def parser(self):
-        test_file = example_folder / "example_no_pyproject_block.py"
-        return EmbeddedMetadata.from_path(test_file)
-
-    def test_missing_none(self):
-        parser = self.parser
-
-        assert parser.pyproject_text is None
-        assert parser.pyproject_toml == {}
-
-    def test_missing_empty(self):
-        parser = self.parser
-
-        assert parser.run_requirements == {
-            "requires-python": None,
-            "dependencies": [],
-        }
-
-
-class TestSpec:
-    # Test that matches the updated spec
-    def test_multi_block(self):
-        test_file = example_folder / "multi_block_discrepency.py"
-        parser = EmbeddedMetadata.from_path(test_file)
-
-        output_text_pyproject = (
-            'run.dependencies = [\n'
-            '    "ducktools-lazyimporter>=0.1.1",\n'
-            ']\n'
-            '///\n'
-            '\n'
-            'Middle Comment\n'
-            '\n'
-            '/// newblock\n'
-            'newblock data\n'
-        )
-
-        assert parser.pyproject_text == output_text_pyproject
-
-
-def test_toml_extension_warning():
-    test_file = example_folder / "toml_warning.py"
-    parser = EmbeddedMetadata.from_path(test_file)
-
-    assert "'pyproject.toml' block found, should be 'pyproject'." in parser.warnings[0]
+            _ = ScriptMetadata.from_path(test_file)
 
 
 def test_valid_types():

--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -1,5 +1,7 @@
 from ducktools.script_metadata_parser import (
     _is_valid_type,
+    parse_file,
+    parse_source,
     ScriptMetadata,
 )
 from pathlib import Path
@@ -14,7 +16,7 @@ class TestParsePEPExample:
     @property
     def file_parser(self):
         test_file = example_folder / "pep-723-sample.py"
-        return ScriptMetadata.from_path(test_file)
+        return parse_file(test_file)
 
     def test_metadata_repr_eq(self):
         parser = self.file_parser
@@ -31,13 +33,13 @@ class TestErrors:
 
     def test_block_not_closed(self):
         test_file = example_folder / "pep-723-sample-noclose.py"
-        metadata = ScriptMetadata.from_path(test_file)
+        metadata = parse_file(test_file)
         assert len(metadata.warnings) > 0
         assert "Potential unclosed block" in metadata.warnings[0]
 
     def test_block_not_closed_eof(self):
         test_file = example_folder / "pep-723-sample-noclose-eof.py"
-        metadata = ScriptMetadata.from_path(test_file)
+        metadata = parse_file(test_file)
 
         assert len(metadata.warnings) > 0
         assert "Potential unclosed block" in metadata.warnings[0]
@@ -46,7 +48,7 @@ class TestErrors:
         test_file = example_folder / "invalid_repeated_block.py"
 
         with pytest.raises(ValueError):
-            _ = ScriptMetadata.from_path(test_file)
+            _ = parse_file(test_file)
 
 
 def test_valid_types():

--- a/tests/test_vs_regex.py
+++ b/tests/test_vs_regex.py
@@ -1,0 +1,37 @@
+import pytest
+
+from ducktools.script_metadata_parser import parse_file
+import compliance_data
+
+# REGEX IMPLEMENTATION #
+import re
+
+REGEX = r"(?m)^# /// (?P<type>[a-zA-Z0-9-]+)$\s(?P<content>(^#(| .*)$\s)+)^# ///$"
+
+
+# From the PEP
+def _stream(script):
+    for match in re.finditer(REGEX, script):
+        yield match.group("type"), "".join(
+            line[2:] if line.startswith("# ") else line[1:]
+            for line in match.group("content").splitlines(keepends=True)
+        )
+
+
+def _get_blocks(pth):
+    with open(pth, "r") as f:
+        src = f.read()
+
+    return {name: content for name, content in _stream(src)}
+
+
+@pytest.mark.parametrize("module_name", dir(compliance_data))
+def test_matches_regex(module_name):
+    module = getattr(compliance_data, module_name)
+    try:
+        metadata = parse_file(module.__file__)
+    except Exception as e:
+        assert module.is_error
+        assert type(e) is type(module.exact_error) and e.args == module.exact_error.args
+    else:
+        assert metadata.blocks == _get_blocks(module.__file__)


### PR DESCRIPTION
The parser will now simply extract the metadata blocks as defined by the inline script metadata PEP.

Handling the TOML data or data in other formats is now left to tools using the library, allowing them to choose which TOML parser and dependency checker they wish to use.